### PR TITLE
[Fix] #28 - 디테일 아카이빙뷰 레이아웃 일부 수정

### DIFF
--- a/33th-SOPKATHON-iOS-TEAM3/33th-SOPKATHON-iOS-TEAM3/Presentation/ArchivingDetail/ViewController/ArchivingDetatilViewController.swift
+++ b/33th-SOPKATHON-iOS-TEAM3/33th-SOPKATHON-iOS-TEAM3/Presentation/ArchivingDetail/ViewController/ArchivingDetatilViewController.swift
@@ -97,17 +97,17 @@ private extension ArchivingDetailViewController {
         }
         
         createdAtLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(62)
+            $0.top.equalToSuperview().offset(96)
             $0.centerX.equalToSuperview()
         }
         
         questionLabel.snp.makeConstraints {
-            $0.top.equalTo(createdAtLabel.snp.bottom).offset(18)
+            $0.top.equalTo(createdAtLabel.snp.bottom).offset(6)
             $0.centerX.equalToSuperview()
         }
         
         detailImageView.snp.makeConstraints {
-            $0.top.equalTo(questionLabel.snp.bottom).offset(20)
+            $0.top.equalTo(questionLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(82)
         }


### PR DESCRIPTION


<img src = "https://github.com/33th-SOPKATHON-TEAM-APP3/SISTAR23-iOS/assets/102219161/ac9b8f42-7e3d-485f-a487-aa7bb16dcbbb" width = 70%>

### 타다 ~~